### PR TITLE
Added Trophies and Map Tags to info

### DIFF
--- a/src/API/TMX.as
+++ b/src/API/TMX.as
@@ -1,5 +1,7 @@
 namespace TMX {
+    dictionary@ mapTags = dictionary();
     const string getMapByUidEndpoint = "https://trackmania.exchange/api/maps/get_map_info/uid/{id}";
+    const string getTagsEndpoint = "https://trackmania.exchange/api/tags/gettags";
 
     // <https://api2.mania.exchange/Method/Index/37>
     Json::Value@ GetMapFromUid(const string &in uid) {
@@ -37,5 +39,23 @@ namespace TMX {
         } catch {}
 #endif
         OpenBrowserURL("https://trackmania.exchange/user/profile/" + TMXAuthorID);
+    }
+
+    void LoadMapTags() {
+        auto req = PluginGetRequest(getTagsEndpoint);
+        req.Start();
+        while (!req.Finished()) yield();
+        if (req.ResponseCode() >= 400 || req.ResponseCode() < 200 || req.Error().Length > 0) {
+            log_warn("[status:" + req.ResponseCode() + "] Error getting Map Tags from TMX: " + req.Error());
+            return;
+        }
+
+        Json::Value@ jsonMapTags = Json::Parse(req.String());
+
+        for(uint i = 0; i < jsonMapTags.Length; i++) {
+            string id = tostring(int(jsonMapTags[i]['ID']));
+            string name = jsonMapTags[i]['Name'];
+            mapTags.Set(id, name);
+        }
     }
 }

--- a/src/ExportShared.as
+++ b/src/ExportShared.as
@@ -47,6 +47,9 @@ namespace MapInfo {
         int TMXAuthorID = -1;
         int TrackID = -1;
         string TrackIDStr = "...";
+        uint TMXAwards;
+        string TMXAwardsStr = "...";
+        string TMXMapTags;
         // When `null`, there's no TMX info. It should never be Json::Type::Null.
         Json::Value@ TMX_Info = null;
 

--- a/src/Main.as
+++ b/src/Main.as
@@ -14,6 +14,7 @@ void Main() {
     startnew(TOTD::LoadTOTDs);
     startnew(MonitorUIVisible);
     startnew(CacheTodaysDate);
+    startnew(TMX::LoadMapTags);
 }
 
 void LoadImGUIFont() {

--- a/src/MapInfo.as
+++ b/src/MapInfo.as
@@ -390,6 +390,19 @@ class MapInfo_Data : MapInfo::Data {
             TMXAuthorID = int(tmxTrack.Get('UserID', -1));
             TrackID = int(tmxTrack.Get('TrackID', -1));
             TrackIDStr = tostring(TrackID);
+            TMXAwards = int(tmxTrack.Get('AwardCount', -1));
+            TMXAwardsStr = tostring(TMXAwards);
+
+            string[]@ TMXMapTagIDs = string(tmxTrack.Get('Tags', -1)).Split(",");
+            if(!TMXMapTagIDs.IsEmpty()) {
+                string mapTag = string(TMX::mapTags[TMXMapTagIDs[0]]);
+                TMXMapTags = mapTag;
+                for(uint i = 1; i < TMXMapTagIDs.Length; i++) {
+                    mapTag = string(TMX::mapTags[TMXMapTagIDs[i]]);
+                    TMXMapTags += ", " + mapTag;
+                }
+            }
+
             @TMX_Info = tmxTrack;
             @TMXButton = NvgButton(vec4(1, 1, 1, .8), vec4(0, 0, 0, 1), CoroutineFunc(this.OnClickTmxButton));
             @TMXAuthorButton = NvgButton(vec4(1, 1, 1, .8), vec4(0, 0, 0, 1), CoroutineFunc(this.OnClickTmxAuthorButton));
@@ -1119,6 +1132,12 @@ class MapInfo_UI : MapInfo_Data {
         lines.InsertLast("by " + ColoredString(g_MapInfo.AuthorDisplayName));
         lines.InsertLast("");
         lines.InsertLast("Published: " + g_MapInfo.DateStr);
+
+        if (SP_ShowTMXAwards)
+            lines.InsertLast("Awards: " + TMXAwards);
+        if (SP_ShowTMXMapTags)
+            lines.InsertLast("Tags: " + TMXMapTags);
+
         if (TOTDStr.Length > 0)
             lines.InsertLast("TOTD: " + TOTDStr);
         lines.InsertLast("# Finishes: " + NbPlayersStr);
@@ -1246,6 +1265,10 @@ class MapInfo_UI : MapInfo_Data {
         // pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, "Author WSID", AuthorWebServicesUserId);
         // pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, "Author AcctID", AuthorAccountId);
         pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, "Published", DateStr, null, 1.0, TMioButton, tmIOLogo);
+        if (SP_ShowTMXAwards)
+            pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, Icons::Trophy + " Awards", TMXAwardsStr, TMXAwardsStr, alpha);
+        if (SP_ShowTMXMapTags)
+            pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, "Tags", TMXMapTags, TMXMapTags, alpha);
         if (drawTotd)
             pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, "TOTD", TOTDStr);
         pos = DrawDataLabels(pos.xyz.xy, col, yStep, col2X, fs, "# Finishes", NbPlayersStr + " (" + TodaysDate + ")");
@@ -1366,11 +1389,13 @@ class MapInfo_UI : MapInfo_Data {
                 UI::TableSetupColumn("key", UI::TableColumnFlags::WidthFixed);
                 UI::TableSetupColumn("value", UI::TableColumnFlags::WidthStretch);
 
-                if (SP_ShowPubDate)   PersistentTableRowStr("Published", DateStr);
-                if (SP_ShowTotDDate)  PersistentTableRowStr("TotD", TOTDStr);
-                if (SP_ShowNbPlayers) PersistentTableRowStr("Players", NbPlayersStr);
-                if (SP_ShowWorstTime) PersistentTableRowStr("Worst Time", WorstTimeStr);
-                if (SP_ShowTMXDojo) PersistentTableRowStr("TMX ID", TrackIDStr);
+                if (SP_ShowPubDate)    PersistentTableRowStr("Published", DateStr);
+                if (SP_ShowTotDDate)   PersistentTableRowStr("TotD", TOTDStr);
+                if (SP_ShowNbPlayers)  PersistentTableRowStr("Players", NbPlayersStr);
+                if (SP_ShowWorstTime)  PersistentTableRowStr("Worst Time", WorstTimeStr);
+                if (SP_ShowTMXDojo)    PersistentTableRowStr("TMX ID", TrackIDStr);
+                if (SP_ShowTMXAwards)  PersistentTableRowStr("TMX Awards", TMXAwardsStr);
+                if (SP_ShowTMXMapTags) PersistentTableRowStr("TMX Tags", TMXMapTags);
                 if (SP_ShowMapComment) PersistentTableRowStr("Map Comment", MapComment);
 
                 if (UI::Button("TM.IO##pw")) OnClickTMioButton();
@@ -1443,6 +1468,10 @@ class MapInfo_UI : MapInfo_Data {
                 DebugTableRowInt("TMXAuthorID", TMXAuthorID);
                 DebugTableRowInt("TrackID", TrackID);
                 DebugTableRowStr("TrackIDStr", TrackIDStr);
+
+                DebugTableRowInt("TMXAwards", TMXAwards);
+                DebugTableRowStr("TMXAwardsStr", TMXAwardsStr);
+                DebugTableRowStr("TMXMapTags", TMXMapTags);
 
                 DebugTableRowStr("TMX API URL", TMX::getMapByUidEndpoint.Replace('{id}', uid));
                 DebugTableRowJsonValueHandle("TMX_Info", TMX_Info);

--- a/src/MapInfo.autodoc.md
+++ b/src/MapInfo.autodoc.md
@@ -64,6 +64,12 @@ Without format codes
 
 #### TMXAuthorID -- `int TMXAuthorID`
 
+#### TMXAwards -- `uint TMXAwards`
+
+#### TMXAwardsStr -- `string TMXAwardsStr`
+
+#### TMXMapTags -- `string TMXMapTags`
+
 #### TMX_Info -- `Json::Value@ TMX_Info`
 
 When `null`, there's no TMX info. It should never be Json::Type::Null.

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -112,3 +112,9 @@ bool SP_ShowTMXDojo = true;
 
 [Setting category="Persistent Window" name="Show Map Comment"]
 bool SP_ShowMapComment = true;
+
+[Setting category="Persistent Window" name="Show TMX Awards"]
+bool SP_ShowTMXAwards = false;
+
+[Setting category="Persistent Window" name="Show TMX Tags"]
+bool SP_ShowTMXMapTags = false;


### PR DESCRIPTION
I added the possibility to display the Award Count and Tags from TMX. Hopefully I changed all necessary places for all exports etc.
I was not sure, where to place / how to name the setting to toggle this extra info. My choice is probably not all that fitting.

I'd really appreaciate, if this feature was added (even if you don't end up using my code) :)