### PR TITLE
fix #33

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -7,7 +7,7 @@ siteid = 320
 
 [script]
 dependencies = ["NadeoServices"]
-optional_dependencies = ["ManiaExchange", "ChampionMedals"]
+optional_dependencies = ["ManiaExchange", "ChampionMedals", "UltrawideUIFix"]
 exports = ["ExportFunc.as"]
 shared_exports = ["ExportShared.as"]
 #__DEFINES__

--- a/src/GameUIElements.as
+++ b/src/GameUIElements.as
@@ -68,12 +68,15 @@ class ManialinkDetectorGroup {
     }
 
     // default for records -- workaround for compact view when loading map
-    vec2 _last_mainFrameAbsPos = vec2(-160, 30);
     vec2 get_mainFrameAbsPos() {
         for (uint i = 0; i < detectors.Length; i++) {
-            if (detectors[i].isElementVisible) return (_last_mainFrameAbsPos = detectors[i].mainFrameAbsPos);
+            if (detectors[i].isElementVisible) return (detectors[i].mainFrameAbsPos);
         }
-        return _last_mainFrameAbsPos;
+#if DEPENDENCY_ULTRAWIDEUIFIX
+            return vec2(-160 - UltrawideUIFix::GetUiShift(), 30);
+#else
+            return vec2(-160, 30);
+#endif
     }
 
     uint get_nbRecordsShown() {


### PR DESCRIPTION
Fix for bugged mapinfo box alignment when there's no leaderboard shown on opening a map (i.e joining a TOTD match, or opening a Royal map in solo mode).
Also adds UltrawideUIFix as optional dependency for this specific case where a hardcoded value is used.