### PR TITLE
Add setting to slide to the left

### DIFF
--- a/src/MapInfo.as
+++ b/src/MapInfo.as
@@ -809,7 +809,8 @@ class MapInfo_UI : MapInfo_Data {
         // if we are not using Compact View
         if (!_minViewWhenRecordsCollapsed) {
             // now, offset everything depending on slider progress
-            nvg::Translate(vec2((1.0 - mainAnim.Progress) * rect.z, 0));
+            float offset = S_CloseDirection == Direction::Left ? mainAnim.Progress - 1.0 : 1.0 - mainAnim.Progress;
+            nvg::Translate(vec2(offset * rect.z, 0));
             // that's all we need.
         } else {
             // don't translate left/right
@@ -965,7 +966,8 @@ class MapInfo_UI : MapInfo_Data {
         nvg::Scale(widthSquish, 1);
         nvg::Scissor(auxInfoRect.x, auxInfoRect.y, auxInfoRect.z, auxInfoRect.w);
         if (!_minViewWhenRecordsCollapsed) {
-            nvg::Translate(vec2((1.0 - mainAnim.Progress) * auxInfoRect.z, 0));
+            float offset = S_CloseDirection == Direction::Left ? mainAnim.Progress - 1.0 : 1.0 - mainAnim.Progress;
+            nvg::Translate(vec2(offset * auxInfoRect.z, 0));
         } else {
             nvg::Translate(vec2(0, mainAnim.Progress ));
         }
@@ -982,7 +984,8 @@ class MapInfo_UI : MapInfo_Data {
         nvg::Scale(widthSquish, 1);
         nvg::Scissor(medalsInfoRect.x, medalsInfoRect.y, medalsInfoRect.z, medalsInfoRect.w);
         if (!_minViewWhenRecordsCollapsed) {
-            nvg::Translate(vec2((1.0 - mainAnim.Progress) * medalsInfoRect.z, 0));
+            float offset = S_CloseDirection == Direction::Left ? mainAnim.Progress - 1.0 : 1.0 - mainAnim.Progress;
+            nvg::Translate(vec2(offset * medalsInfoRect.z, 0));
         }
         nvg::BeginPath();
         DrawBgRect(medalsInfoRect.xy, medalsInfoRect.zw);
@@ -1054,7 +1057,8 @@ class MapInfo_UI : MapInfo_Data {
         nvg::Scale(widthSquish, 1);
         nvg::Scissor(topAuxInfoRect.x, topAuxInfoRect.y, topAuxInfoRect.z, topAuxInfoRect.w);
         if (!_minViewWhenRecordsCollapsed) {
-            nvg::Translate(vec2((1.0 - mainAnim.Progress) * topAuxInfoRect.z, 0));
+            float offset = S_CloseDirection == Direction::Left ? mainAnim.Progress - 1.0 : 1.0 - mainAnim.Progress;
+            nvg::Translate(vec2(offset * topAuxInfoRect.z, 0));
         }
 
         nvg::BeginPath();

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -4,6 +4,14 @@ bool S_ShowMapInfo = true;
 [Setting category="General" name="Compact View when Records Collapsed" description="When enabled, MapInfo will stay visible when the records are collapsed."]
 bool S_MinViewWhenRecordsCollapsed = true;
 
+enum Direction {
+    Left,
+    Right
+};
+
+[Setting category="General" name="Close animation direction" description="The direction of the animation used when MapInfo is closed"]
+Direction S_CloseDirection = Direction::Right;
+
 [Setting category="General" name="Retrieve author's current username"]
 bool S_AuthorCurrentName = true;
 


### PR DESCRIPTION
Like the title says, it adds a setting to allow sliding to the left instead, matching the records widget's animation

https://github.com/user-attachments/assets/3114a28d-68b0-47e1-88b5-d8f1a3a5828c

The animation's duration doesn't match the widget's, but that seems to be another issue (sadly I couldn't find the culprit)

Fixes #17 

